### PR TITLE
Router extra subscribe

### DIFF
--- a/switchio/apps/routers.py
+++ b/switchio/apps/routers.py
@@ -10,7 +10,7 @@ from functools import partial
 from collections import OrderedDict
 from collections import Counter
 from .. import utils
-from ..marks import coroutine, callback
+from ..marks import coroutine, callback, extend_attr_list
 from ..apps import app
 
 
@@ -123,9 +123,11 @@ class Router(object):
         """Signal a router to discontinue execution.
         """
 
-    def __init__(self, guards=None, reject_on_guard=True):
+    def __init__(self, guards=None, reject_on_guard=True, subscribe=()):
         self.guards = guards or {}
         self.guard = reject_on_guard
+        # subscribe for any additional event types requested by the user
+        extend_attr_list(self.on_park, 'switchio_events_sub', subscribe)
         self.route = PatternRegistrar()
 
     def prepost(self, pool):
@@ -165,8 +167,10 @@ class Router(object):
             await sess.hangup('NO_ROUTE_DESTINATION')
 
     @staticmethod
-    async def bridge(sess, match, router, dest_url=None, out_profile=None,
-               gateway=None, proxy=None):
+    async def bridge(
+        sess, match, router, dest_url=None, out_profile=None,
+        gateway=None, proxy=None
+    ):
         """A handy generic bridging function.
         """
         sess.bridge(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,14 +68,16 @@ def containers(request, confdir):
         docker = request.getfixturevalue('dockerctl')
         with docker.run(
             'safarov/freeswitch',
-            volumes={confdir: {'bind': '/etc/freeswitch/'}},
+            volumes={confdir: {'bind': '/etc/freeswitch/'},
+                     'freeswitch-sounds': '/usr/share/freeswitch/sounds'},
+            environment={'SOUND_RATES': '8000:16000',
+                         'SOUND_TYPES': 'music:en-us-callie'},
             num=request.config.option.ncntrs
         ) as containers:
             yield containers
     else:
         pytest.skip(
-            "You must specify `--use-docker` to activate containers"
-        )
+            "You must specify `--use-docker` to activate containers")
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
Support subscribing for extra event types through a `subscribe=(,)` kwarg to `switchio.apps.router.Router`.

This allows for pre-registering for events which will be awaited in router functions.
Fixes #50.