### PR TITLE
Sendmsg support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,16 @@ before_install:
     - export PATH="$PWD:$PATH"
     - cd ..
 
-  # pull and start up freeswitch container bound to 'lo'
-  # - docker pull safarov/freeswitch
-  # - docker run -d --net=host -e SOUND_RATES=8000:16000 -e SOUND_TYPES=music:en-us-callie -v freeswitch-sounds:/usr/share/freeswitch/sounds -v $TRAVIS_BUILD_DIR/conf/ci-minimal/:/etc/freeswitch safarov/freeswitch
-  # - docker ps -a
+     # pull and start up freeswitch container bound to 'lo'
+     # - docker pull safarov/freeswitch
+     # - docker run -d --net=host -e SOUND_RATES=8000:16000 -e SOUND_TYPES=music:en-us-callie -v freeswitch-sounds:/usr/share/freeswitch/sounds -v $TRAVIS_BUILD_DIR/conf/ci-minimal/:/etc/freeswitch safarov/freeswitch
+     # - docker ps -a
 
 install:
-  # - pip install -U tox
-  - cd $TRAVIS_BUILD_DIR
-  - pip install . -r requirements-test.txt
+    # - pip install -U tox
+    - cd $TRAVIS_BUILD_DIR
+    - pip install . -r requirements-test.txt
 
 # NOTE: no support for pandas/pytables yet
 script:
-  - pytest --use-docker tests/
+    - pytest --use-docker tests/ -p no:logging

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
   # pull and start up freeswitch container bound to 'lo'
   # - docker pull safarov/freeswitch
-  # - docker run -d --net=host -v $TRAVIS_BUILD_DIR/conf/ci-minimal/:/etc/freeswitch safarov/freeswitch
+  # - docker run -d --net=host -e SOUND_RATES=8000:16000 -e SOUND_TYPES=music:en-us-callie -v freeswitch-sounds:/usr/share/freeswitch/sounds -v $TRAVIS_BUILD_DIR/conf/ci-minimal/:/etc/freeswitch safarov/freeswitch
   # - docker ps -a
 
 install:

--- a/switchio/apps/blockers.py
+++ b/switchio/apps/blockers.py
@@ -34,7 +34,7 @@ class CalleeBlockOnInvite(object):
         else:  # str case
             self.action = partial(Session.hangup, cause=value)
 
-    @event_callback("CHANNEL_CREATE")
+    @callback("CHANNEL_CREATE")
     def on_invite(self, sess):
         if sess.is_inbound():
             self.action(sess)
@@ -72,7 +72,7 @@ class CalleeRingback(object):
         if self.auto_duration:
             self.callee_hup_after = value
 
-    @event_callback("CHANNEL_CALLSTATE")
+    @callback("CHANNEL_CALLSTATE")
     def on_cs(self, sess):
         self.log.debug("'{}' sess CS is '{}'".format(
             sess['Call-Direction'], sess['Channel-Call-State']))

--- a/switchio/apps/call_gen.py
+++ b/switchio/apps/call_gen.py
@@ -331,7 +331,7 @@ class Originator(object):
         self._report_on_none()
 
     @marks.event_callback("CHANNEL_HANGUP")
-    def _handle_hangup(self, sess, job):
+    def _handle_hangup(self, sess):
         self._report_on_none()
         # if sess.call.sessions and sess.is_outbound():
         #     # we normally expect that the caller hangs up

--- a/switchio/apps/measure/cdr.py
+++ b/switchio/apps/measure/cdr.py
@@ -164,7 +164,7 @@ class CDR(object):
     def on_answer(self, sess):
         sess.times['answer'] = sess.time
 
-    @event_callback('CHANNEL_HANGUP')
+    @event_callback('CHANNEL_DESTROY')
     def log_stats(self, sess, job):
         """Append measurement data only once per call
         """

--- a/switchio/apps/players.py
+++ b/switchio/apps/players.py
@@ -29,7 +29,8 @@ class TonePlay(object):
 
         # play infinite tones on calling leg
         if sess.is_outbound():
-            sess.broadcast('playback::{loops=-1}tone_stream://%(251,0,1004)')
+            sess.playback('tone_stream://%(251,0,1004)',
+                          params={'loops': '-1'})
 
 
 RecInfo = namedtuple("RecInfo", "host caller callee")

--- a/switchio/connection.py
+++ b/switchio/connection.py
@@ -217,6 +217,12 @@ class Connection(object):
         queue.task_done()
         return event
 
+    def execute(self, uuid, app, arg='', params='', loops=1):
+        """Execute a dialplan ``app`` with argument ``arg``.
+        """
+        return self.protocol.sendmsg(uuid, 'execute', app, arg, params,
+                                     loops=loops)
+
     def api(self, cmd, errcheck=True, block=False, timeout=0.5):
         '''Invoke api command (with error checking by default).
         '''

--- a/switchio/handlers.py
+++ b/switchio/handlers.py
@@ -56,9 +56,6 @@ class EventListener(object):
         self.sessions_per_app = Counter()
         self.max_limit = max_limit
         self.call_tracking_header = call_tracking_header
-        # job synchronization
-        self._lookup_blocker = mp.Event()  # used block event loop temporarily
-        self._lookup_blocker.set()
         # state reset
         self.reset()
 
@@ -66,7 +63,7 @@ class EventListener(object):
         for evname, cbtype, cb in get_callbacks(self, only='handler'):
             self.event_loop.add_handler(evname, cb)
 
-    def register_job(self, event, **kwargs):
+    def register_job(self, future, **kwargs):
         '''Register for a job to be handled when the appropriate event arrives.
         Once an event corresponding to the job is received, the bgjob event
         handler will 'consume' it and invoke its callback.
@@ -82,28 +79,9 @@ class EventListener(object):
         -------
         bj : an instance of Job (a background job)
         '''
-        bj = Job(event, **kwargs)
+        bj = Job(future, **kwargs)
         self.bg_jobs[bj.uuid] = bj
         return bj
-
-    def block_jobs(self):
-        '''Block the event loop from processing
-        background job events (useful for registering for
-        job events - see `self.register_job`)
-
-        WARNING
-        -------
-        This will block the event loop thread permanently starting on the next
-        received background job event. Be sure to run 'unblock_jobs'
-        immediately after registering your job.
-        '''
-        self._lookup_blocker.clear()
-
-    def unblock_jobs(self):
-        '''Unblock the event loop from processing
-        background job events
-        '''
-        self._lookup_blocker.set()
 
     def count_jobs(self):
         return len(self.bg_jobs)
@@ -181,78 +159,63 @@ class EventListener(object):
         err = '-ERR'
         job_uuid = e.get('Job-UUID')
         body = e.get('Body')
+
         # always report errors even for jobs which we aren't tracking
         if err in body:
             resp = body.strip(err).strip()
             error = True
             self.log.debug("job '{}' failed with:\n{}".format(
                            job_uuid, str(body)))
+        elif ok in body:
+            resp = body.strip(ok + '\n')
 
-        if job_uuid in self.bg_jobs:
-            job = self.bg_jobs.get(job_uuid, None)
+        job = self.bg_jobs.get(job_uuid, None)
+        if not job:
+            job = Job(event=e)
         else:
-            # might be in the middle of inserting a job
-            self._lookup_blocker.wait()
-            job = self.bg_jobs.get(job_uuid, None)
+            job.events.update(e)
 
-        # if this job is registered, process it
-        if job:
-            job.update(e)
-            consumed = True
+        # attempt to lookup an associated session
+        sess = self.sessions.get(job.sess_uuid or resp, None)
+
+        if error:
             # if the job returned an error, report it and remove the job
-            if error:
-                # if this job corresponds to a tracked session then
-                # remove it as well
+            self.log.error(
+                "Job '{}' corresponding to session '{}'"
+                " failed with:\n{}".format(
+                    job_uuid,
+                    job.sess_uuid, str(body))
+                )
+            job.fail(resp)  # fail the job
+            # always pop failed jobs
+            self.bg_jobs.pop(job_uuid)
+            # append the id for later lookup and discard?
+            self.failed_jobs[resp] += 1
+            consumed = True
+
+        else:  # OK case
+            if sess:
+                # special case: the bg job event returns a known originated
+                # session's (i.e. pre-registered) uuid in its body
                 if job.sess_uuid:
-                    self.log.error(
-                        "Job '{}' corresponding to session '{}'"
-                        " failed with:\n{}".format(
-                            job_uuid,
-                            job.sess_uuid, str(body))
-                        )
-                    # session may already have been popped in hangup handler?
-                    # TODO make a special method for popping sessions?
-                    sess = self.sessions.pop(job.sess_uuid, None)
-                    if sess:
-                        # remove any call containing this session
-                        call = sess.call
-                        if call:
-                            call = self.calls.pop(call.uuid, None)
-                        else:
-                            self.log.debug("No Call containing Session "
-                                           "'{}'".format(sess.uuid))
-                    else:
-                        self.log.warn("No session corresponding to bj '{}'"
-                                      .format(job_uuid))
-                job.fail(resp)  # fail the job
-                # always pop failed jobs
-                self.bg_jobs.pop(job_uuid)
-                # append the id for later lookup and discard?
-                self.failed_jobs[resp] += 1
 
-            # success, associate with any related session
-            elif ok in body:
-                resp = body.strip(ok + '\n')
+                    assert str(job.sess_uuid) == str(resp), \
+                        ("""Session uuid '{}' <-> BgJob uuid '{}' mismatch!?
+                         """.format(job.sess_uuid, resp))
 
-                # special case: the bg job event returns an originated
-                # session's uuid in its body
-                sess = self.sessions.get(resp, None)
-                if sess:
-                    if job.sess_uuid:
-                        assert str(job.sess_uuid) == str(resp), \
-                            ("""Session uuid '{}' <-> BgJob uuid '{}' mismatch!?
-                             """.format(job.sess_uuid, resp))
-
-                    # reference this job in the corresponding session
-                    # self.sessions[resp].bg_job = job
-                    sess.bg_job = job
-                    self.log.debug("Job '{}' was sucessful".format(
-                                   job_uuid))
-                # run the job's callback
-                job(resp)
+                # reference this job in the corresponding session
+                # self.sessions[resp].bg_job = job
+                sess.bg_job = job
+                self.log.debug("Job '{}' was sucessful".format(
+                               job_uuid))
+                consumed = True
             else:
-                self.log.warning("Received unexpected job message:\n{}"
-                                 .format(body))
+                self.log.warn("No session corresponding to bj '{}'"
+                              .format(job_uuid))
+
+            # run the job's callback
+            job(resp)
+
         return consumed, sess, job
 
     @handler('CHANNEL_CREATE')

--- a/switchio/loop.py
+++ b/switchio/loop.py
@@ -153,7 +153,7 @@ class EventLoop(object):
             self._thread.daemon = True  # die with parent
             self._thread.start()
 
-    def connect(self, loop=None, timeout=3, **conn_kwargs):
+    def connect(self, loop=None, timeout=3, debug=False, **conn_kwargs):
         '''Initialize underlying receive connection.
         '''
         # TODO: once we remove SWIG/py27 support this check can be removed
@@ -165,7 +165,7 @@ class EventLoop(object):
                 return
 
         if not self.is_alive():
-            self._launch_bg_loop()
+            self._launch_bg_loop(debug=debug)
             while not self.loop:
                 time.sleep(0.1)
 

--- a/switchio/models.py
+++ b/switchio/models.py
@@ -303,7 +303,7 @@ class Session(object):
         else:  # set a stream file delimiter
             self.setvar('playback_delimiter', delim)
 
-        varset = '{{{vars}}}'.format(','.join(pairs)) if pairs else ''
+        varset = '{{{}}}'.format(','.join(pairs)) if pairs else ''
         args = '{streams}{start}'.format(
                 streams=delim.join(args),
                 start='@@{}'.format(start_sample) if start_sample else '',

--- a/switchio/models.py
+++ b/switchio/models.py
@@ -10,6 +10,7 @@ from collections import deque, defaultdict
 import multiprocessing as mp
 from concurrent import futures
 from pprint import pprint
+import warnings
 from . import utils
 
 
@@ -229,7 +230,7 @@ class Session(object):
     def setvar(self, var, value):
         """Set variable to value
         """
-        self.broadcast("set::{}={}".format(var, value))
+        self.execute('set', '='.join((var, value)))
 
     def setvars(self, params):
         """Set all variables in map `params` with a single command
@@ -241,7 +242,7 @@ class Session(object):
     def unsetvar(self, var):
         """Unset a channel var.
         """
-        self.broadcast("unset::{}".format(var))
+        return self.execute("unset", var)
 
     def answer(self):
         self.con.api("uuid_answer {}".format(self.uuid))
@@ -302,15 +303,12 @@ class Session(object):
         else:  # set a stream file delimiter
             self.setvar('playback_delimiter', delim)
 
-        self.broadcast(
-            '{app}::{varset}{streams}{start} {leg}'.format(
-                app=app,
+        varset = '{{{vars}}}'.format(','.join(pairs)) if pairs else ''
+        args = '{streams}{start}'.format(
                 streams=delim.join(args),
                 start='@@{}'.format(start_sample) if start_sample else '',
-                leg=leg,
-                varset='{{{vars}}}'.format(','.join(pairs)) if pairs else '',
             )
-        )
+        self.execute(app, args, params=varset)
 
     def start_record(self, path, rx_only=False, stereo=False, rate=16000):
         '''Record audio from this session to a local file on the slave filesystem
@@ -326,7 +324,7 @@ class Session(object):
             self.setvar('RECORD_STEREO', 'true')
 
         self.setvar('record_sample_rate', '{}'.format(rate))
-        self.broadcast('record_session::{}'.format(path))
+        self.execute('record_session', path)
 
     def stop_record(self, path='all', delay=0):
         '''Stop recording audio from this session to a local file on the slave
@@ -336,13 +334,13 @@ class Session(object):
             https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+stop_record_session
         '''
         if delay:
-            self.con.api(
-                "sched_api +{delay} none uuid_broadcast {sessid} "
-                "stop_record_session::{path}".
-                format(sessid=self.uuid, delay=delay, path=path)
+            self.execute(
+                "sched_api",
+                "+{delay} none stop_record_session {path}".
+                format(delay=delay, path=path)
             )
         else:
-            self.broadcast('stop_record_session::{}'.format(path))
+            self.execute('stop_record_session', path)
 
     def record(self, action, path, rx_only=True):
         '''Record audio from this session to a local file on the slave filesystem
@@ -356,9 +354,9 @@ class Session(object):
         self.con.api('uuid_record {} {} {}'.format(self.uuid, action, path))
 
     def echo(self):
-        '''Echo back all audio recieved
+        '''Echo back all audio recieved.
         '''
-        self.broadcast('echo::')
+        self.execute('echo')
 
     def bypass_media(self, state):
         '''Re-invite a bridged node out of the media path for this session
@@ -383,6 +381,12 @@ class Session(object):
         self.con.api('uuid_park {}'.format(self.uuid))
         return self.recv('CHANNEL_PARK')
 
+    def execute(self, cmd, arg='', params='', loops=1):
+        """Execute an application async.
+        """
+        return self.con.execute(
+            self.uuid, cmd, arg, params=params, loops=loops)
+
     def broadcast(self, path, leg='', delay=None, hangup_cause=None):
         """Execute an application async on a chosen leg(s) with optional hangup
         afterwards. If provided tell FS to schedule the app ``delay`` seconds
@@ -394,6 +398,11 @@ class Session(object):
         .. _sched_broadcast:
             https://freeswitch.org/confluence/display/FREESWITCH/mod_commands#mod_commands-sched_broadcast
         """
+        warnings.warn((
+            "`Session.broadcast()` has been deprecated due to unreliable\
+            `uuid_broadcast` behaviour in FreeSWITCH core. Use\
+            `Session.execute()` instead."),
+            DeprecationWarning)
         if not delay:
             return self.con.api(
                 'uuid_broadcast {} {} {}'.format(self.uuid, path, leg))
@@ -414,8 +423,9 @@ class Session(object):
         if gateway:
             profile = 'gateway/{}'.format(gateway)
 
-        self.broadcast(
-            "bridge::{{{varset}}}sofia/{}/{}{dest}".format(
+        self.execute(
+            'bridge',
+            "{{{varset}}}sofia/{}/{}{dest}".format(
                 profile if profile else self['variable_sofia_profile_name'],
                 dest_url if dest_url else self['variable_sip_req_uri'],
                 varset=','.join(pairs),
@@ -455,7 +465,7 @@ class Session(object):
         .. _respond:
             https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+respond
         """
-        self.broadcast('respond::{}'.format(response))
+        self.execute('respond', response)
 
     def deflect(self, uri):
         """Send a refer to the client.
@@ -464,7 +474,13 @@ class Session(object):
 
              <action application="deflect" data="sip:someone@somewhere.com" />
          """
-        self.broadcast("deflect::{}".format(uri))
+        self.execute("deflect", uri)
+
+    def speak(self, text, engine='flite', voice='kal', timer_name=''):
+        """Speak, young switch (alpha).
+        """
+        return self.execute(
+            'speak', '|'.join((engine, voice, text, timer_name)))
 
     def is_inbound(self):
         """Return bool indicating whether this is an inbound session

--- a/switchio/protocol.py
+++ b/switchio/protocol.py
@@ -113,6 +113,11 @@ class InboundProtocol(asyncio.Protocol):
             # self.log.log(
             #     utils.TRACE, "Event packet:\n{}".format(pformat(event)))
             ctype = event.get('Content-Type', None)
+
+            if ctype == 'command/reply':
+                if event.get('Job-UUID'):
+                    ctype = 'job/reply'
+
             futures = fut_map.get(ctype, None)
 
             if ctype == 'text/disconnect-notice':
@@ -260,7 +265,7 @@ class InboundProtocol(asyncio.Protocol):
 
     def bgapi(self, cmd, errcheck=True):
         # TODO: drop ``errcheck`` here - it's legacy and should be the default
-        future = self.sendrecv('bgapi {}'.format(cmd))
+        future = self.sendrecv('bgapi {}'.format(cmd), resp_type='job/reply')
         future.cmd = 'bgapi ' + cmd
         if errcheck:
             future.add_done_callback(self._handle_cmd_resp)

--- a/switchio/utils.py
+++ b/switchio/utils.py
@@ -43,8 +43,11 @@ TRACE = 5
 def get_logger(name=None):
     '''Return the package log or a sub-log for `name` if provided.
     '''
-    log = logging.getLogger('switchio')
-    return log.getChild(name) if name else log
+    log = rlog = logging.getLogger('switchio')
+    if name and name != 'switchio':
+        log = rlog.getChild(name)
+        log.level = rlog.level
+    return log
 
 
 def log_to_stderr(level=None):

--- a/tests/apps/test_measure.py
+++ b/tests/apps/test_measure.py
@@ -280,7 +280,7 @@ def test_with_orig(get_orig, measure, storer):
     orig.start()
 
     # wait for all calls to come up then hupall
-    orig.waitwhile(lambda: orig.total_originated_sessions < orig.max_offered)
+    orig.waitwhile(lambda: orig.total_originated_sessions < orig.max_offered, timeout=20)
     orig.hupall()
     start = time.time()
     orig.waitwhile(

--- a/tests/apps/test_originator.py
+++ b/tests/apps/test_originator.py
@@ -59,7 +59,7 @@ def test_rep_fields(get_orig):
     # verify invalid field causes failure
     orig.rep_fields_func = lambda: {'invalidname': 'kitty'}
     orig.start()
-    time.sleep(0.05)
+    time.sleep(0.2)
     # burst loop thread should fail due to missing 'field' kwarg to str.format
     assert orig.stopped()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ def fssock(fs_socks):
 
 
 @pytest.fixture
-def cps(request):
+def cps(request, travis):
     """It appears as though fs can deliver channel create events at
     around 250 cps (don't know if we can even track faster
     then this) IF the calls are bridged directly using an xml
@@ -149,7 +149,7 @@ def cps(request):
     get around 165 for slow servers...
     """
     cps = int(request.config.option.cps)
-    return cps if cps < 250 else 250
+    return cps if not travis else 80
 
 
 @pytest.yield_fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,7 +127,7 @@ def checkcalls(scenario, ael, travis):
             # wait for events to arrive and be processed
             start = time.time()
             msg = "Wasn't quite fast enough to track {} cps".format(rate)
-            while ael.count_calls() != limit:
+            while ael.count_calls() != limit and (time.time() - start) < duration + 3:
                 time.sleep(0.0001)
             else:
                 assert ael.count_calls() == limit, msg

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -255,7 +255,7 @@ class TestListener:
         checkcalls(rate=cps, limit=cps, call_count=cps, duration=4)
 
     @pytest.mark.usefixtures('load_limits')
-    def test_track_1kcapacity(self, proxy_dp, checkcalls, cps):
+    def test_track_1kcapacity(self, proxy_dp, checkcalls, cps, travis):
         '''load fs with up to 1000 simultaneous calls
         and test we (are fast enough to) track all the created sessions
 
@@ -263,7 +263,7 @@ class TestListener:
         this tes may fail intermittently as it depends on the
         speed of the fs server under test
         '''
-        limit = 1000
+        limit = 1000 if not travis else 500
         duration = limit / cps + 1  # h = E/lambda (erlang formula)
         checkcalls(rate=cps, limit=limit, duration=duration, sleep=duration)
 


### PR DESCRIPTION
This completes #52 and must be landed prior to the tests added in #49 and #51.

I ended up cleaning up a lot of stuff to get this working alongside background jobs (which turn out have the same response event type as `sendmsg` requests) including:

- using `CHANNEL_DESTROY` events to trigger session destruction 
- removing a bunch of insane logic from the `BACKGROUND_JOB` handler which was required because we were previously using `CHANNEL_HANGUP` as the session destroyer