### PR TITLE
Pytest no live logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,6 @@ python:
 
 
 before_install:
-    # build and install latest SWIG
-    - git clone https://github.com/swig/swig.git
-    - cd swig
-    - git checkout rel-3.0.12
-    - ./autogen.sh
-    - ./configure --prefix=$HOME/swig
-    - make
-    - make install
-    - export PATH="$HOME/swig/bin/:$PATH"
-    - cd ..
-
     # build and install SIPp
     - git clone https://github.com/SIPp/sipp.git
     - cd sipp

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ install:
 
 # NOTE: no support for pandas/pytables yet
 script:
-    - pytest --use-docker tests/ -p no:logging
+    - pytest --use-docker tests/

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=3.4.2
 pdbpp
 
 # pysipp for call tracking testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,10 @@ def containers(request, confdir):
         docker = request.getfixturevalue('dockerctl')
         with docker.run(
             'safarov/freeswitch',
-            volumes={confdir: {'bind': '/etc/freeswitch/'},
-                     'freeswitch-sounds': '/usr/share/freeswitch/sounds'},
+            volumes={
+                confdir: {'bind': '/etc/freeswitch/'},
+                'freeswitch-sounds': {'bind': '/usr/share/freeswitch/sounds'},
+            },
             environment={'SOUND_RATES': '8000:16000',
                          'SOUND_TYPES': 'music:en-us-callie'},
             num=request.config.option.ncntrs


### PR DESCRIPTION
Let's us go back to using the built-in plugin defaults in `pytest` due to the adjustments made in pytest-dev/pytest#3124 thanks to @nicoddemus!

This can be merged after that branch is released of course.